### PR TITLE
Use "type": "wp-cli-package" to designate this as a WP-CLI package

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,7 @@
 {
     "name": "aaemnnosttv/wp-cli-dotenv-command",
     "description": "Dotenv commands for WP-CLI",
+    "type": "wp-cli-package",
     "homepage": "https://aaemnnost.tv/wp-cli-commands/dotenv/",
     "support": {
         "issues": "https://github.com/aaemnnosttv/wp-cli-dotenv-command/issues"


### PR DESCRIPTION
See https://github.com/wp-cli/wp-cli/issues/2567
