### PR TITLE
v2.0

### DIFF
--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,2 +1,0 @@
-coverage_clover: build/logs/clover.xml
-service_name: travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
 
 php:
-    - 5.5
     - 5.6
     - 7.0
+    - 7.1
+    - 7.2
 
 install: composer install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,8 +18,6 @@ script:
     - composer run-phpunit
     - composer run-behat
 
-after_success: travis_retry php vendor/bin/coveralls -v
-
 cache:
   directories:
     - vendor

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,9 +14,7 @@ before_script:
     - mysql -e 'CREATE DATABASE wp_cli_test;' -uroot
     - mysql -e 'GRANT ALL PRIVILEGES ON wp_cli_test.* TO "wp_cli_test"@"localhost" IDENTIFIED BY "password1"' -uroot
 
-script:
-    - composer run-phpunit
-    - composer run-behat
+script: composer test
 
 cache:
   directories:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,12 @@
 # Changelog
 
+## v2.0.0 (2018-05-21)
+- Drop support for PHP 5.5
+- Remove dependency on beloved `tightenco/collect` library
+- Package now has zero dependencies (other than WP-CLI)
+
 ## v1.0.2 (2016-08-30)
-- Fixed a regression when installed with tightenco/collect 5.3 and up
+- Fixed a regression when installed with `tightenco/collect` 5.3 and up
 
 ## v1.0.1 (2016-08-15)
 - Fixed a regression where commented-out variables were showing up in `list`

--- a/command.php
+++ b/command.php
@@ -4,5 +4,3 @@ if (defined('WP_CLI') && class_exists('WP_CLI', false)) {
     WP_CLI::add_command('dotenv', WP_CLI_Dotenv\WP_CLI\DotenvCommand::class);
     WP_CLI::add_command('dotenv salts', WP_CLI_Dotenv\WP_CLI\SaltsCommand::class);
 }
-
-class_alias(\WP_CLI_Dotenv\Dotenv\Collection::class, 'Illuminate\\Support\\Collection');

--- a/command.php
+++ b/command.php
@@ -4,3 +4,5 @@ if (defined('WP_CLI') && class_exists('WP_CLI', false)) {
     WP_CLI::add_command('dotenv', WP_CLI_Dotenv\WP_CLI\DotenvCommand::class);
     WP_CLI::add_command('dotenv salts', WP_CLI_Dotenv\WP_CLI\SaltsCommand::class);
 }
+
+class_alias(\WP_CLI_Dotenv\Dotenv\Collection::class, 'Illuminate\\Support\\Collection');

--- a/composer.json
+++ b/composer.json
@@ -22,8 +22,8 @@
         "php": "^5.5 | ^7.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8",
-        "wp-cli/wp-cli": "^0.22.0",
+        "phpunit/phpunit": "^5.0",
+        "wp-cli/wp-cli": "^1.0",
         "satooshi/php-coveralls": "^1.0",
         "behat/behat": "2.5.*"
     },

--- a/composer.json
+++ b/composer.json
@@ -15,8 +15,8 @@
         }
     ],
     "scripts": {
-        "run-phpunit": "vendor/bin/phpunit --colors=always",
-        "run-behat": "WP_CLI_BIN_DIR=$PWD/vendor/bin vendor/bin/behat --ansi --format=progress"
+        "run-phpunit": "phpunit --colors=always",
+        "run-behat": "behat --ansi"
     },
     "require": {
         "php": "^5.5 | ^7.0"

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "run-behat": "behat --ansi"
     },
     "require": {
-        "php": "^5.5 | ^7.0"
+        "php": "^5.6 | ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^5.0",

--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,10 @@
         }
     ],
     "scripts": {
+        "test": [
+            "@composer run-phpunit",
+            "@composer run-behat"
+        ],
         "run-phpunit": "phpunit --colors=always",
         "run-behat": "behat --ansi"
     },

--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,6 @@
     "require-dev": {
         "phpunit/phpunit": "^5.0",
         "wp-cli/wp-cli": "^1.0",
-        "satooshi/php-coveralls": "^1.0",
         "behat/behat": "2.5.*"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -19,8 +19,7 @@
         "run-behat": "WP_CLI_BIN_DIR=$PWD/vendor/bin vendor/bin/behat --ansi --format=progress"
     },
     "require": {
-        "php": "^5.5 | ^7.0",
-        "tightenco/collect": "5.2.*"
+        "php": "^5.5 | ^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^4.8",

--- a/features/dotenv-init.feature
+++ b/features/dotenv-init.feature
@@ -2,8 +2,15 @@ Feature: Test 'dotenv init' command.
 
   Scenario: It can create a .env file in the working directory
     Given an empty directory
+    When I run `pwd`
+    And save STDOUT as {PWD}
+
     When I run `wp dotenv init`
     Then the .env file should exist
+    And STDOUT should be:
+      """
+      Success: {PWD}/.env created.
+      """
 
   Scenario: It can create a .env file using a different filename
     Given an empty directory

--- a/src/Dotenv/Collection.php
+++ b/src/Dotenv/Collection.php
@@ -1,0 +1,208 @@
+<?php
+
+namespace WP_CLI_Dotenv\Dotenv;
+
+use Traversable;
+
+class Collection implements \ArrayAccess, \IteratorAggregate
+{
+    protected $items;
+
+    /**
+     * Collection constructor.
+     *
+     * @param array $items
+     */
+    public function __construct($items = [])
+    {
+        $this->items = ($items instanceof Collection) ? $items->all() : $items;
+    }
+
+    public static function make($items)
+    {
+        return new static($items);
+    }
+
+    public function all()
+    {
+        return $this->items;
+    }
+
+    public function map($callback)
+    {
+        $keys   = array_keys($this->items);
+        $values = array_map($callback, $this->items, $keys);
+
+        return new static(array_combine($keys, $values));
+    }
+
+    public function contains($callback)
+    {
+        return null !== $this->first($callback);
+    }
+
+    public function first($callback = null, $default = null)
+    {
+        if ($callback instanceof \Closure) {
+            foreach ($this->items as $key => $value) {
+                if ($callback($key, $value)) {
+                    return $value;
+                }
+            }
+
+            return $default;
+        }
+
+        return reset($this->items);
+    }
+
+    public function count()
+    {
+        return count($this->items);
+    }
+
+    public function implode($glue)
+    {
+        return implode($glue, $this->items);
+    }
+
+    public function filter($callback = null)
+    {
+        if ($callback instanceof \Closure) {
+            return new static(array_filter($this->items, $callback, ARRAY_FILTER_USE_BOTH));
+        }
+
+        return new static(array_filter($this->items));
+    }
+
+    public function reject($callback)
+    {
+        return $this->filter(function ($value, $key) use ($callback) {
+            return ! $callback($value, $key);
+        });
+    }
+
+    public function isEmpty()
+    {
+        return empty($this->items);
+    }
+
+    public function reduce($callback, $initial)
+    {
+        return new static(array_reduce($this->items, $callback, $initial));
+    }
+
+    public function get($key, $default = null)
+    {
+        return $this->offsetExists($key) ? $this->offsetGet($key) : $default;
+    }
+
+    public function put($key, $value)
+    {
+        $this->offsetSet($key, $value);
+    }
+
+    public function search($needle)
+    {
+        if ($needle instanceof \Closure) {
+            foreach ($this->items as $key => $value) {
+                if ($needle($value, $key)) {
+                    return $key;
+                }
+            }
+            return false;
+        }
+
+        return array_search($needle, $this->items);
+    }
+
+    public function push($value)
+    {
+        array_push($this->items, $value);
+
+        return $this;
+    }
+
+    /**
+     * Whether a offset exists
+     * @link  http://php.net/manual/en/arrayaccess.offsetexists.php
+     *
+     * @param mixed $offset <p>
+     *                      An offset to check for.
+     *                      </p>
+     *
+     * @return boolean true on success or false on failure.
+     * </p>
+     * <p>
+     * The return value will be casted to boolean if non-boolean was returned.
+     * @since 5.0.0
+     */
+    public function offsetExists($offset)
+    {
+        return array_key_exists($offset, $this->items);
+    }
+
+    /**
+     * Offset to retrieve
+     * @link  http://php.net/manual/en/arrayaccess.offsetget.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to retrieve.
+     *                      </p>
+     *
+     * @return mixed Can return all value types.
+     * @since 5.0.0
+     */
+    public function offsetGet($offset)
+    {
+        return $this->offsetExists($offset) ? $this->items[ $offset ] : null;
+    }
+
+    /**
+     * Offset to set
+     * @link  http://php.net/manual/en/arrayaccess.offsetset.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to assign the value to.
+     *                      </p>
+     * @param mixed $value  <p>
+     *                      The value to set.
+     *                      </p>
+     *
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetSet($offset, $value)
+    {
+        $this->items[ $offset ] = $value;
+    }
+
+    /**
+     * Offset to unset
+     * @link  http://php.net/manual/en/arrayaccess.offsetunset.php
+     *
+     * @param mixed $offset <p>
+     *                      The offset to unset.
+     *                      </p>
+     *
+     * @return void
+     * @since 5.0.0
+     */
+    public function offsetUnset($offset)
+    {
+        unset($this->items[ $offset ]);
+    }
+
+    /**
+     * Retrieve an external iterator
+     * @link  http://php.net/manual/en/iteratoraggregate.getiterator.php
+     * @return Traversable An instance of an object implementing <b>Iterator</b> or
+     * <b>Traversable</b>
+     * @since 5.0.0
+     */
+    public function getIterator()
+    {
+        return new \ArrayIterator($this->items);
+    }
+}
+

--- a/src/Dotenv/File.php
+++ b/src/Dotenv/File.php
@@ -2,7 +2,6 @@
 
 namespace WP_CLI_Dotenv\Dotenv;
 
-use InvalidArgumentException;
 use Illuminate\Support\Collection;
 use WP_CLI_Dotenv\Dotenv\Exception\FilePermissionsException;
 use WP_CLI_Dotenv\Dotenv\Exception\NonExistentFileException;

--- a/src/Dotenv/File.php
+++ b/src/Dotenv/File.php
@@ -2,7 +2,6 @@
 
 namespace WP_CLI_Dotenv\Dotenv;
 
-use Illuminate\Support\Collection;
 use WP_CLI_Dotenv\Dotenv\Exception\FilePermissionsException;
 use WP_CLI_Dotenv\Dotenv\Exception\NonExistentFileException;
 

--- a/src/Dotenv/FileLines.php
+++ b/src/Dotenv/FileLines.php
@@ -2,8 +2,6 @@
 
 namespace WP_CLI_Dotenv\Dotenv;
 
-use Illuminate\Support\Collection;
-
 class FileLines extends Collection
 {
     /**

--- a/src/Dotenv/Line.php
+++ b/src/Dotenv/Line.php
@@ -127,7 +127,7 @@ class Line implements LineInterface
      */
     public static function wrapping_quote_for($string)
     {
-        return collect(["'", '"'])
+        return Collection::make(["'", '"'])
             ->first(function ($key, $quote) use ($string) {
                 return static::wraps_value($quote, $string);
             }, '');

--- a/src/Salts/Salts.php
+++ b/src/Salts/Salts.php
@@ -3,7 +3,7 @@
 namespace WP_CLI_Dotenv\Salts;
 
 use Exception;
-use Illuminate\Support\Collection;
+use WP_CLI_Dotenv\Dotenv\Collection;
 
 class Salts
 {

--- a/src/WP_CLI/AssocArgs.php
+++ b/src/WP_CLI/AssocArgs.php
@@ -2,7 +2,7 @@
 
 namespace WP_CLI_Dotenv\WP_CLI;
 
-use Illuminate\Support\Collection;
+use WP_CLI_Dotenv\Dotenv\Collection;
 
 /**
  * Class AssocArgs

--- a/src/WP_CLI/Command.php
+++ b/src/WP_CLI/Command.php
@@ -87,7 +87,7 @@ class Command
         /**
          * realpath will return false if path does not exist
          */
-        return realpath($path) ?: $path;
+        return realpath($path) ?: str_replace('/./', '/', $path);
     }
 
 

--- a/src/WP_CLI/SaltsCommand.php
+++ b/src/WP_CLI/SaltsCommand.php
@@ -4,9 +4,9 @@ namespace WP_CLI_Dotenv\WP_CLI;
 
 use Exception;
 use WP_CLI;
+use WP_CLI_Dotenv\Dotenv\Collection;
 use WP_CLI_Dotenv\Dotenv\File;
 use WP_CLI_Dotenv\Salts\Salts;
-use Illuminate\Support\Collection;
 
 /**
  * Manage WordPress salts in .env format

--- a/tests/unit/DotenvFileLinesTest.php
+++ b/tests/unit/DotenvFileLinesTest.php
@@ -1,19 +1,10 @@
 <?php
 
 use WP_CLI_Dotenv\Dotenv\FileLines;
-use Illuminate\Support\Collection;
 
 class DotenvFileLinesTest extends PHPUnit_Framework_TestCase
 {
     use WP_CLI_Dotenv\Fixtures;
-
-    /**
-     * @test
-     */
-    function it_is_a_collection()
-    {
-        $this->assertInstanceOf(Collection::class, new FileLines);
-    }
 
     /**
      * @test

--- a/tests/unit/SaltsTest.php
+++ b/tests/unit/SaltsTest.php
@@ -2,7 +2,6 @@
 
 use WP_CLI_Dotenv\Fixtures;
 use WP_CLI_Dotenv\Salts\Salts;
-use Illuminate\Support\Collection;
 
 class SaltsTest extends PHPUnit_Framework_TestCase
 {
@@ -15,8 +14,6 @@ class SaltsTest extends PHPUnit_Framework_TestCase
     {
         $salts = new Salts($this->get_fixture_path('wp-org-api-generated-salts-php'));
         $collection = $salts->collect();
-
-        $this->assertInstanceOf(Collection::class, $collection);
 
         $this->assertEquals($collection->all(),
             [


### PR DESCRIPTION
This version is the same version you all know and love. No new features have been added, but support for PHP 5.5 has been dropped, and the package no longer has any dependencies 🎉 

Anyone who continues to need support for PHP 5.5 may continue to use the 1.x version, by using the `^1.0` version constraint in their `~/.wp-cli/packages/composer.json` file until ready to upgrade.

Resolves #13 