### PR TITLE
Remove version from installation instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Same as `generate`, but will update all keys for salts with new values.
 
 As of WP-CLI v0.23, you may install the dotenv command using the new `package` command:
 ```
-wp package install aaemnnosttv/wp-cli-dotenv-command
+wp package install aaemnnosttv/wp-cli-dotenv-command:^2.0
 ```
 
 For installation with prior versions of WP-CLI, [see the wiki](https://github.com/aaemnnosttv/wp-cli-dotenv-command/wiki).

--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Same as `generate`, but will update all keys for salts with new values.
 
 As of WP-CLI v0.23, you may install the dotenv command using the new `package` command:
 ```
-wp package install aaemnnosttv/wp-cli-dotenv-command:^1.0
+wp package install aaemnnosttv/wp-cli-dotenv-command
 ```
 
 For installation with prior versions of WP-CLI, [see the wiki](https://github.com/aaemnnosttv/wp-cli-dotenv-command/wiki).


### PR DESCRIPTION
The current version provided in the installations instructions does not match the latest version available. Removed to avoid future users copying the wrong version.